### PR TITLE
Update $ref targets from tag URIs to schema URIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,3 +2,5 @@
 ==================
 
 - Initial schemas for ``gwcs``. [#1]
+
+- Update ``$ref`` targets from tag URIs to schema URIs. [#3]

--- a/resources/schemas/stsci.edu/gwcs/direction_cosines-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/direction_cosines-1.0.0.yaml
@@ -27,7 +27,7 @@ examples:
           transform_type: to_direction_cosines
 
 allOf:
-  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - object:
     properties:
       transform_type:

--- a/resources/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
@@ -27,7 +27,7 @@ examples:
           transform_type: to_direction_cosines
 
 allOf:
-  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - object:
     properties:
       transform_type:

--- a/resources/schemas/stsci.edu/gwcs/frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/frame-1.0.0.yaml
@@ -59,14 +59,14 @@ properties:
   reference_frame:
     description: |
       The reference frame.
-    $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+    $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
 
   unit:
     description: |
       Units for each axis.
     type: array
     items:
-      $ref: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+      $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
 
   axis_physical_types:
     description: |

--- a/resources/schemas/stsci.edu/gwcs/grating_equation-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/grating_equation-1.0.0.yaml
@@ -31,7 +31,7 @@ examples:
           output: wavelength
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       groove_density:
@@ -39,7 +39,7 @@ allOf:
           The groove density of the grating
         anyOf:
           - type: number
-          - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+          - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
       order:
         description: |
           Spectral order

--- a/resources/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
@@ -31,7 +31,7 @@ examples:
           output: wavelength
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
       groove_density:
@@ -39,7 +39,7 @@ allOf:
           The groove density of the grating
         anyOf:
           - type: number
-          - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+          - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
       order:
         description: |
           Spectral order

--- a/resources/schemas/stsci.edu/gwcs/label_mapper-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/label_mapper-1.0.0.yaml
@@ -72,7 +72,7 @@ examples:
             n_inputs: 2
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       mapper:
@@ -87,8 +87,8 @@ allOf:
           It could be a dictionary which maps tuples to labels or floating point numbers to labels.
 
         anyOf:
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
-          - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
           - type: object
             properties:
               labels:
@@ -104,7 +104,7 @@ allOf:
               models:
                 type: array
                 items:
-                  $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+                  $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
 
       inputs:
         type: array
@@ -113,7 +113,7 @@ allOf:
         description: |
           Names of inputs.
       inputs_mapping:
-        $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+        $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
         description: |
           [mapping](https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/transform/remap_axes-1.1.0.html)
       atol:

--- a/resources/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
@@ -72,7 +72,7 @@ examples:
             n_inputs: 2
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
       mapper:
@@ -87,8 +87,8 @@ allOf:
           It could be a dictionary which maps tuples to labels or floating point numbers to labels.
 
         anyOf:
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
-          - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
           - type: object
             properties:
               labels:
@@ -104,7 +104,7 @@ allOf:
               models:
                 type: array
                 items:
-                  $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+                  $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
 
       inputs:
         type: array
@@ -113,7 +113,7 @@ allOf:
         description: |
           Names of inputs.
       inputs_mapping:
-        $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+        $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
         description: |
           [mapping](https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/transform/remap_axes-1.3.0.html)
       atol:

--- a/resources/schemas/stsci.edu/gwcs/regions_selector-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/regions_selector-1.0.0.yaml
@@ -58,7 +58,7 @@ examples:
 
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       label_mapper:
@@ -96,11 +96,10 @@ allOf:
               A transform for each region. The order should match the order of labels.
             type: array
             items:
-              $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       undefined_transform_value:
         description: |
           Value to be returned if there's no transform defined for the inputs.
         type: number
-
     required: [label_mapper, inputs, outputs, selector]
 ...

--- a/resources/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
@@ -58,7 +58,7 @@ examples:
 
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
       label_mapper:
@@ -96,7 +96,7 @@ allOf:
               A transform for each region. The order should match the order of labels.
             type: array
             items:
-              $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       undefined_transform_value:
         description: |
           Value to be returned if there's no transform defined for the inputs.

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
@@ -13,7 +13,7 @@ description: |
      \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       B_coef:
@@ -21,7 +21,7 @@ allOf:
           B coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -31,7 +31,7 @@ allOf:
           C coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
@@ -13,7 +13,7 @@ description: |
      \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
       B_coef:
@@ -21,7 +21,7 @@ allOf:
           B coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -31,7 +31,7 @@ allOf:
           C coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
@@ -9,7 +9,7 @@ description: |
   Sellmeier equation for glass used by Zemax
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       B_coef:
@@ -17,7 +17,7 @@ allOf:
           B coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -27,7 +27,7 @@ allOf:
           C coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -37,7 +37,7 @@ allOf:
           Thermal D coefficients of the glass.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -47,7 +47,7 @@ allOf:
           Thermal E coefficients of the glass.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
@@ -9,7 +9,7 @@ description: |
   Sellmeier equation for glass used by Zemax
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
       B_coef:
@@ -17,7 +17,7 @@ allOf:
           B coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -27,7 +27,7 @@ allOf:
           C coefficients in Sellmeier equation.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -37,7 +37,7 @@ allOf:
           Thermal D coefficients of the glass.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3
@@ -47,7 +47,7 @@ allOf:
           Thermal E coefficients of the glass.
         anyOf:
           - type: array
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
         items:
           type: number
         minItems: 3

--- a/resources/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -10,5 +10,5 @@ description: |
   Inputs are index of refraction and direction cosines.
   Outputs are direction cosines.
 
-$ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+$ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
 ...

--- a/resources/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
@@ -10,5 +10,5 @@ description: |
   Inputs are index of refraction and direction cosines.
   Outputs are direction cosines.
 
-$ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+$ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
 ...

--- a/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -28,7 +28,7 @@ examples:
           transform_type: cartesian_to_spherical
 
 allOf:
-  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - object:
     properties:
       wrap_lon_at:

--- a/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
@@ -28,7 +28,7 @@ examples:
           transform_type: cartesian_to_spherical
 
 allOf:
-  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - object:
     properties:
       wrap_lon_at:

--- a/resources/schemas/stsci.edu/gwcs/step-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/step-1.0.0.yaml
@@ -25,7 +25,7 @@ properties:
       exists only to describe the frames and units of the
       final output axes.
     anyOf:
-      - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+      - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       - type: 'null'
     default: null
 

--- a/resources/schemas/stsci.edu/gwcs/step-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/step-1.1.0.yaml
@@ -25,7 +25,7 @@ properties:
       exists only to describe the frames and units of the
       final output axes.
     anyOf:
-      - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+      - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       - type: 'null'
     default: null
 

--- a/resources/schemas/stsci.edu/gwcs/temporal_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/temporal_frame-1.0.0.yaml
@@ -34,14 +34,14 @@ properties:
   reference_frame:
     description: |
       The reference frame.
-    $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
+    $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
 
   unit:
     description: |
       Units for each axis.
     type: array
     items:
-      $ref: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+      $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
 
   axis_physical_types:
     description: |


### PR DESCRIPTION
The new extension code requires that `$ref` targets be schema URIs and not tag URIs.