### PR TITLE
Change manifest URI authority to asdf-format.org

### DIFF
--- a/resources/manifests/gwcs-1.0.0.yaml
+++ b/resources/manifests/gwcs-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://stsci.edu/schemas/gwcs/manifests/gwcs-schemas-1.0
-extension_uri: asdf://stsci.edu/schemas/gwcs/manifests/gwcs-schemas-1.0
+id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0
+extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0
 title: gwcs extension 1.0
 description: |-
   A set of tags for serializing STScI gwcs models.

--- a/src/asdf_wcs_schemas/integration.py
+++ b/src/asdf_wcs_schemas/integration.py
@@ -36,6 +36,6 @@ def get_resource_mappings():
         ),
         DirectoryResourceMapping(
             resources_root / "manifests",
-            "asdf://stsci.edu/schemas/gwcs/manifests/",
+            "asdf://asdf-format.org/astronomy/gwcs/manifests/",
         ),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,5 @@ import yaml
 @pytest.fixture(scope="session")
 def manifest():
     return yaml.safe_load(
-        asdf.get_config().resource_manager["asdf://stsci.edu/schemas/gwcs/manifests/gwcs-schemas-1.0"]
+        asdf.get_config().resource_manager["asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0"]
     )


### PR DESCRIPTION
Since these schemas are intended to be provided by ASDF for general use, we should use asdf-format.org as the URI authority for new URIs.