### PR TITLE
Add recursive yaml finding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pathlib import Path
 from setuptools import setup, find_packages
 
 
@@ -10,11 +11,14 @@ package_dir = {
     "asdf_wcs_schemas.resources": "resources",
 }
 
+
+def package_yaml_files(directory):
+    paths = sorted(Path(directory).rglob("*.yaml"))
+    return [str(p.relative_to(directory)) for p in paths]
+
+
 package_data = {
-    "asdf_wcs_schemas.resources": [
-        "manifests/*.yaml",
-        "schemas/stsci.edu/gwcs/*.yaml"
-    ],
+    "asdf_wcs_schemas.resources": package_yaml_files("resources"),
 }
 
 setup(


### PR DESCRIPTION
In https://github.com/asdf-format/asdf-transform-schemas/pull/32, a recursive yaml file finding was added. This was done so that arbitrarily deep directory trees for schemas and other resource file could be used without modification of setup.py for non-editable installations. This PR brings that functionality into asdf-wcs-schemas.