### PR TITLE
Split gwcs manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Update documentation to be consistent with rest of ASDF. [#12]
 - Switch over to ``pyproject.toml`` for build configuration. [#20]
+- Remove duplicate tag versions in gwcs manifest 1.0.0 (adding 1.0.1)
+  and add 1.1.0 with only the newest tags [#46]
 
 0.1.1 (2021-12-03)
 ------------------

--- a/docs/frames.rst
+++ b/docs/frames.rst
@@ -11,13 +11,12 @@ Current
 .. asdf-autoschemas::
 
   celestial_frame-1.0.0
+  composite_frame-1.0.0
   frame-1.0.0
   frame2d-1.0.0
   spectral_frame-1.0.0
-  frame2d-1.0.0
   stokes_frame-1.0.0
   temporal_frame-1.0.0
-  composite_frame-1.0.0
 
 Legacy
 ------

--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -14,3 +14,4 @@ GWCS
    :standard_prefix: manifests
 
    gwcs-1.0.0
+   gwcs-1.1.0

--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -13,5 +13,14 @@ GWCS
    :schema_root: ../resources
    :standard_prefix: manifests
 
-   gwcs-1.0.0
+   gwcs-1.0.1
    gwcs-1.1.0
+
+Legacy
+------
+
+.. asdf-autoschemas::
+   :schema_root: ../resources
+   :standard_prefix: manifests
+
+   gwcs-1.0.0

--- a/resources/manifests/gwcs-1.0.1.yaml
+++ b/resources/manifests/gwcs-1.0.1.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
-id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0
-extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0
-title: gwcs extension 1.0
+id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.1
+extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.1
+title: gwcs extension 1.0.1
 description: |-
   A set of tags for serializing STScI gwcs models.
 asdf_standard_requirement:
@@ -20,12 +20,6 @@ tags:
     Represents a set of frames
 - tag_uri: "tag:stsci.edu:gwcs/direction_cosines-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/direction_cosines-1.0.0"
-  title: >
-    Convert coordinates between vector and direction cosine form.
-  description: |
-    This schema is for transforms which convert to and from direction cosines.
-- tag_uri: "tag:stsci.edu:gwcs/direction_cosines-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/direction_cosines-1.1.0"
   title: >
     Convert coordinates between vector and direction cosine form.
   description: |
@@ -51,14 +45,6 @@ tags:
     Supports two models:
      - Given incident angle and wavelength compute the refraction/difraction angle.
      - Given an incident angle and a refraction angle compute the wavelength.
-- tag_uri: "tag:stsci.edu:gwcs/grating_equation-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/grating_equation-1.1.0"
-  title: >
-    A grating equation model.
-  description: |
-    Supports two models:
-     - Given incident angle and wavelength compute the refraction/difraction angle.
-     - Given an incident angle and a refraction angle compute the wavelength.
 - tag_uri: "tag:stsci.edu:gwcs/label_mapper-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/label_mapper-1.0.0"
   title: >
@@ -72,27 +58,8 @@ tags:
     [regions_selector](ref:regions_selector-1.0.0)
     returns the transform corresponding to this label. This maps inputs
     (e.g. pixels on a detector) to transforms uniquely.
-- tag_uri: "tag:stsci.edu:gwcs/label_mapper-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/label_mapper-1.1.0"
-  title: >
-    Represents a mapping from a coordinate value to a label.
-  description: |
-    A label mapper instance maps inputs to a label.  It is used together
-    with
-    [regions_selector](ref:regions_selector-1.1.0). The
-    [label_mapper](ref:label_mapper-1.1.0)
-    returns the label corresponding to given inputs. The
-    [regions_selector](ref:regions_selector-1.1.0)
-    returns the transform corresponding to this label. This maps inputs
-    (e.g. pixels on a detector) to transforms uniquely.
 - tag_uri: "tag:stsci.edu:gwcs/regions_selector-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/regions_selector-1.0.0"
-  title: >
-    Represents a discontinuous transform.
-  description: |
-    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
-- tag_uri: "tag:stsci.edu:gwcs/regions_selector-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/regions_selector-1.1.0"
   title: >
     Represents a discontinuous transform.
   description: |
@@ -107,35 +74,13 @@ tags:
     $$ n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
        \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
        \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
-- tag_uri: "tag:stsci.edu:gwcs/sellmeier_glass-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.1.0"
-  title: >
-    Sellmeier equation for glass
-  description: |
-    Sellmeier equation for glass.
-
-    $$ n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
-       \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
-       \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
 - tag_uri: "tag:stsci.edu:gwcs/sellmeier_zemax-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.0.0"
   title: Sellmeier equation for glass used by Zemax
   description: |
     Sellmeier equation for glass used by Zemax
-- tag_uri: "tag:stsci.edu:gwcs/sellmeier_zemax-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.1.0"
-  title: Sellmeier equation for glass used by Zemax
-  description: |
-    Sellmeier equation for glass used by Zemax
 - tag_uri: "tag:stsci.edu:gwcs/snell3d-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/snell3d-1.0.0"
-  title: Snell Law in 3D space
-  description: |
-    Snell Law in 3D.
-    Inputs are index of refraction and direction cosines.
-    Outputs are direction cosines.
-- tag_uri: "tag:stsci.edu:gwcs/snell3d-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/snell3d-1.1.0"
   title: Snell Law in 3D space
   description: |
     Snell Law in 3D.
@@ -153,20 +98,8 @@ tags:
   description: |
     This schema is for transforms which convert between spherical coordinates
     (on the unit sphere) and Cartesian coordinates.
-- tag_uri: "tag:stsci.edu:gwcs/spherical_cartesian-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.1.0"
-  title: >
-    Convert coordinates between spherical and Cartesian coordinates.
-  description: |
-    This schema is for transforms which convert between spherical coordinates
-    (on the unit sphere) and Cartesian coordinates.
 - tag_uri: "tag:stsci.edu:gwcs/step-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/step-1.0.0"
-  title: >
-    Describes a single step of a WCS transform pipeline.
-  description: >
-- tag_uri: "tag:stsci.edu:gwcs/step-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/step-1.1.0"
   title: >
     Describes a single step of a WCS transform pipeline.
   description: >
@@ -182,14 +115,6 @@ tags:
   description: >
 - tag_uri: "tag:stsci.edu:gwcs/wcs-1.0.0"
   schema_uri: "http://stsci.edu/schemas/gwcs/wcs-1.0.0"
-  title: >
-    A system for describing generalized world coordinate transformations.
-  description: >
-    ASDF WCS is a way of specifying transformations (usually from
-    detector space to world coordinate space and back) by using the
-    transformations in the `transform-schema` module.
-- tag_uri: "tag:stsci.edu:gwcs/wcs-1.1.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/wcs-1.1.0"
   title: >
     A system for describing generalized world coordinate transformations.
   description: >

--- a/resources/manifests/gwcs-1.1.0.yaml
+++ b/resources/manifests/gwcs-1.1.0.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
-id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0
-extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0
-title: gwcs extension 1.0
+id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.1.0
+extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.1.0
+title: gwcs extension 1.1
 description: |-
   A set of tags for serializing STScI gwcs models.
 asdf_standard_requirement:
@@ -18,8 +18,8 @@ tags:
   title: A set of frames
   description: |-
     Represents a set of frames
-- tag_uri: "tag:stsci.edu:gwcs/direction_cosines-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/direction_cosines-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/direction_cosines-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/direction_cosines-1.1.0"
   title: >
     Convert coordinates between vector and direction cosine form.
   description: |
@@ -37,35 +37,35 @@ tags:
   description: |
     These objects are designed to be nested in arbitrary ways to build up
     transformation pipelines out of a number of low-level pieces.
-- tag_uri: "tag:stsci.edu:gwcs/grating_equation-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/grating_equation-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/grating_equation-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/grating_equation-1.1.0"
   title: >
     A grating equation model.
   description: |
     Supports two models:
      - Given incident angle and wavelength compute the refraction/difraction angle.
      - Given an incident angle and a refraction angle compute the wavelength.
-- tag_uri: "tag:stsci.edu:gwcs/label_mapper-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/label_mapper-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/label_mapper-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/label_mapper-1.1.0"
   title: >
     Represents a mapping from a coordinate value to a label.
   description: |
     A label mapper instance maps inputs to a label.  It is used together
     with
-    [regions_selector](ref:regions_selector-1.0.0). The
-    [label_mapper](ref:label_mapper-1.0.0)
+    [regions_selector](ref:regions_selector-1.1.0). The
+    [label_mapper](ref:label_mapper-1.1.0)
     returns the label corresponding to given inputs. The
-    [regions_selector](ref:regions_selector-1.0.0)
+    [regions_selector](ref:regions_selector-1.1.0)
     returns the transform corresponding to this label. This maps inputs
     (e.g. pixels on a detector) to transforms uniquely.
-- tag_uri: "tag:stsci.edu:gwcs/regions_selector-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/regions_selector-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/regions_selector-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/regions_selector-1.1.0"
   title: >
     Represents a discontinuous transform.
   description: |
     Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
-- tag_uri: "tag:stsci.edu:gwcs/sellmeier_glass-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/sellmeier_glass-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.1.0"
   title: >
     Sellmeier equation for glass
   description: |
@@ -74,13 +74,13 @@ tags:
     $$ n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
        \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
        \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
-- tag_uri: "tag:stsci.edu:gwcs/sellmeier_zemax-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/sellmeier_zemax-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.1.0"
   title: Sellmeier equation for glass used by Zemax
   description: |
     Sellmeier equation for glass used by Zemax
-- tag_uri: "tag:stsci.edu:gwcs/snell3d-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/snell3d-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/snell3d-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/snell3d-1.1.0"
   title: Snell Law in 3D space
   description: |
     Snell Law in 3D.
@@ -91,15 +91,15 @@ tags:
   title: >
     Represents a spectral frame.
   description: >
-- tag_uri: "tag:stsci.edu:gwcs/spherical_cartesian-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/spherical_cartesian-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.1.0"
   title: >
     Convert coordinates between spherical and Cartesian coordinates.
   description: |
     This schema is for transforms which convert between spherical coordinates
     (on the unit sphere) and Cartesian coordinates.
-- tag_uri: "tag:stsci.edu:gwcs/step-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/step-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/step-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/step-1.1.0"
   title: >
     Describes a single step of a WCS transform pipeline.
   description: >
@@ -113,8 +113,8 @@ tags:
   title: >
     Represents a temporal frame.
   description: >
-- tag_uri: "tag:stsci.edu:gwcs/wcs-1.0.0"
-  schema_uri: "http://stsci.edu/schemas/gwcs/wcs-1.0.0"
+- tag_uri: "tag:stsci.edu:gwcs/wcs-1.1.0"
+  schema_uri: "http://stsci.edu/schemas/gwcs/wcs-1.1.0"
   title: >
     A system for describing generalized world coordinate transformations.
   description: >

--- a/resources/manifests/gwcs-1.1.0.yaml
+++ b/resources/manifests/gwcs-1.1.0.yaml
@@ -2,7 +2,7 @@
 ---
 id: asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.1.0
 extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.1.0
-title: gwcs extension 1.1
+title: gwcs extension 1.1.0
 description: |-
   A set of tags for serializing STScI gwcs models.
 asdf_standard_requirement:

--- a/resources/schemas/stsci.edu/gwcs/celestial_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/celestial_frame-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/celestial_frame-1.0.0"
-tag: "tag:stsci.edu:gwcs/celestial_frame-1.0.0"
 
 title: >
   Represents a celestial frame.

--- a/resources/schemas/stsci.edu/gwcs/composite_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/composite_frame-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/composite_frame-1.0.0"
-tag: "tag:stsci.edu:gwcs/composite_frame-1.0.0"
 
 title: >
   Represents a set of frames.

--- a/resources/schemas/stsci.edu/gwcs/direction_cosines-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/direction_cosines-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/direction_cosines-1.0.0"
-tag: "tag:stsci.edu:gwcs/direction_cosines-1.0.0"
 
 title: >
   Convert coordinates between vector and direction cosine form.

--- a/resources/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/direction_cosines-1.1.0"
-tag: "tag:stsci.edu:gwcs/direction_cosines-1.1.0"
 
 title: >
   Convert coordinates between vector and direction cosine form.

--- a/resources/schemas/stsci.edu/gwcs/frame2d-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/frame2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/frame2d-1.0.0"
-tag: "tag:stsci.edu:gwcs/frame2d-1.0.0"
 
 title: >
   Represents a 2D frame.

--- a/resources/schemas/stsci.edu/gwcs/grating_equation-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/grating_equation-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/grating_equation-1.0.0"
-tag: "tag:stsci.edu:gwcs/grating_equation-1.0.0"
 
 title: >
   A grating equation model.

--- a/resources/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/grating_equation-1.1.0"
-tag: "tag:stsci.edu:gwcs/grating_equation-1.1.0"
 
 title: >
   A grating equation model.

--- a/resources/schemas/stsci.edu/gwcs/label_mapper-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/label_mapper-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/label_mapper-1.0.0"
-tag: "tag:stsci.edu:gwcs/label_mapper-1.0.0"
 title: >
   Represents a mapping from a coordinate value to a label.
 description: |

--- a/resources/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/label_mapper-1.1.0"
-tag: "tag:stsci.edu:gwcs/label_mapper-1.1.0"
 title: >
   Represents a mapping from a coordinate value to a label.
 description: |

--- a/resources/schemas/stsci.edu/gwcs/regions_selector-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/regions_selector-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/regions_selector-1.0.0"
-tag: "tag:stsci.edu:gwcs/regions_selector-1.0.0"
 title: >
   Represents a discontinuous transform.
 description: |

--- a/resources/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/regions_selector-1.1.0"
-tag: "tag:stsci.edu:gwcs/regions_selector-1.1.0"
 title: >
   Represents a discontinuous transform.
 description: |

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.0.0"
-tag: "tag:stsci.edu:gwcs/sellmeier_glass-1.0.0"
 title: Sellmeier equation for glass
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.1.0"
-tag: "tag:stsci.edu:gwcs/sellmeier_glass-1.1.0"
 title: Sellmeier equation for glass
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.0.0"
-tag: "tag:stsci.edu:gwcs/sellmeier_zemax-1.0.0"
 title: Sellmeier equation for glass used by Zemax
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.1.0"
-tag: "tag:stsci.edu:gwcs/sellmeier_zemax-1.1.0"
 title: Sellmeier equation for glass used by Zemax
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/snell3d-1.0.0"
-tag: "tag:stsci.edu:gwcs/snell3d-1.0.0"
 title: Snell Law in 3D space
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/snell3d-1.1.0"
-tag: "tag:stsci.edu:gwcs/snell3d-1.1.0"
 title: Snell Law in 3D space
 
 description: |

--- a/resources/schemas/stsci.edu/gwcs/spectral_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/spectral_frame-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/spectral_frame-1.0.0"
-tag: "tag:stsci.edu:gwcs/spectral_frame-1.0.0"
 
 title: >
   Represents a spectral frame.

--- a/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.0.0"
-tag: "tag:stsci.edu:gwcs/spherical_cartesian-1.0.0"
 
 title: >
   Convert coordinates between spherical and Cartesian coordinates.

--- a/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.1.0"
-tag: "tag:stsci.edu:gwcs/spherical_cartesian-1.1.0"
 
 title: >
   Convert coordinates between spherical and Cartesian coordinates.

--- a/resources/schemas/stsci.edu/gwcs/step-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/step-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/step-1.0.0"
-tag: "tag:stsci.edu:gwcs/step-1.0.0"
 
 title: >
   Describes a single step of a WCS transform pipeline.

--- a/resources/schemas/stsci.edu/gwcs/step-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/step-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/step-1.1.0"
-tag: "tag:stsci.edu:gwcs/step-1.1.0"
 
 title: >
   Describes a single step of a WCS transform pipeline.

--- a/resources/schemas/stsci.edu/gwcs/stokes_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/stokes_frame-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/stokes_frame-1.0.0"
-tag: "tag:stsci.edu:gwcs/stokes_frame-1.0.0"
 
 title: >
   Represents a stokes frame

--- a/resources/schemas/stsci.edu/gwcs/temporal_frame-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/temporal_frame-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/temporal_frame-1.0.0"
-tag: "tag:stsci.edu:gwcs/temporal_frame-1.0.0"
 
 title: >
   Represents a temporal frame.

--- a/resources/schemas/stsci.edu/gwcs/wcs-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/wcs-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/wcs-1.0.0"
-tag: "tag:stsci.edu:gwcs/wcs-1.0.0"
 
 title: >
   A system for describing generalized world coordinate transformations.

--- a/resources/schemas/stsci.edu/gwcs/wcs-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/gwcs/wcs-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/gwcs/wcs-1.1.0"
-tag: "tag:stsci.edu:gwcs/wcs-1.1.0"
 
 title: >
   A system for describing generalized world coordinate transformations.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ import pytest
 import yaml
 
 
-@pytest.fixture(scope="session")
-def manifest():
+@pytest.fixture(scope="session", params=["1.0.0", "1.1.0"])
+def manifest(request):
     return yaml.safe_load(
-        asdf.get_config().resource_manager["asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0"]
+        asdf.get_config().resource_manager[f"asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-{request.param}"]
     )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -93,33 +93,3 @@ def test_required(schema):
                 assert False, message
 
     asdf.treeutil.walk(schema, callback)
-
-
-# def test_flowstyle(schema, manifest):
-#    is_tag_schema = schema["id"] in {t["schema_uri"] for t in manifest["tags"]}
-#
-#    if is_tag_schema:
-#        found_flowstyle = False
-#
-#        def callback(node):
-#            nonlocal found_flowstyle
-#            if isinstance(node, Mapping) and node.get("flowStyle") == "block":
-#                found_flowstyle = True
-#
-#        asdf.treeutil.walk(schema, callback)
-#
-#        assert found_flowstyle, "Schemas associated with a tag must specify flowStyle: block"
-#    else:
-#        def callback(node):
-#            if isinstance(node, Mapping):
-#                assert "flowStyle" not in node, "Only schemas associated with a tag may specify flowStyle"
-#
-#        asdf.treeutil.walk(schema, callback)
-
-
-def test_tag(schema, valid_tag_uris):
-    def callback(node):
-        if isinstance(node, Mapping) and "tag" in node:
-            assert node["tag"] in valid_tag_uris
-
-    asdf.treeutil.walk(schema, callback)


### PR DESCRIPTION
The gwcs manifest contains duplicate tag versions:
https://github.com/asdf-format/asdf-wcs-schemas/blob/f3af7e20462a7a92b29192a6415302188040aaa8/resources/manifests/gwcs/gwcs-1.0.0.yaml#L183-L198

As the corresponding gwcs converters do not implement `select_tag`:
https://github.com/spacetelescope/gwcs/blob/77d0b016aecda380cadc2ec85f2dbbed2aa03bbf/gwcs/converters/wcs.py#L12-L24

These duplicates are causing the converters to always write out the oldest tag (due to the converter inheriting a `select_tag` from the `Converter` [base class](https://github.com/asdf-format/asdf/blob/a5b2b2d94f2fc71746f896c6d322439a27dd0bdd/asdf/extension/_converter.py#L58) that selects the first tag after sorting them by version).

This PR splits the gwcs manifest `gwcs-1.0.0.yaml` into 3 versions:
- `1.0.0` unchanged, preserved to allow backwards compatibility with older installs of gwcs
- `1.0.1` all new tags removed so that none are duplicated
- `1.1.0` all old tags removed so that none are duplicated

A companion gwcs PR enables support for the above manifests: https://github.com/spacetelescope/gwcs/pull/469

The general order of PRs should be:
- #45  (local testing supports that this should allow the gwcs dev testing to pass)
- this PR and the gwcs PR (ordering of these two is not important)
