### PR TITLE
use default branch for gwcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: spacetelescope/gwcs
-          ref: master
           path: gwcs
       - name: Set up Python 3.11
         uses: actions/setup-python@v2


### PR DESCRIPTION
This would allow gwcs to rename the default branch.