### PR TITLE
docs/fix-latex-logo-path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Update documentation configuration settings to be consistent with other asdf subprojects [#65]
+- Fix typo in latex logo path and footer copyright author text [#66]
 
 0.4.0 (2024-03-09)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ configuration = conf["project"]
 
 project = configuration["name"]
 author = f"{configuration['authors'][0]['name']} <{configuration['authors'][0]['email']}>"
-copyright = f"{datetime.datetime.now().year}, {configuration['authors'][0]['name']}"
+copyright = f"{datetime.datetime.now().year}, {author}"
 
 release = get_distribution(configuration["name"]).version
 version = ".".join(release.split(".")[:2])
@@ -167,7 +167,7 @@ graphviz_dot_args = [
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
 
-latex_logo = "_static/images/logo-light.png"
+latex_logo = "_static/images/logo-light-mode.png"
 
 
 # -- Options for manual page output --------------------------------------------


### PR DESCRIPTION
- fix typo in latex logo filename
- fix copyright text in footer ( Display `The ASDF Developers <help@stsci.edu>` instead of `{'name': 'The ASDF Developers', 'email': 'help@stsci.edu'}`)