### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
 ]
 test = [
     'pytest >= 4.6.0',
+    'pytest-asdf-plugin >= 0.1.0',
     'asdf >= 2.8.0',
     'asdf-astropy',
 ]


### PR DESCRIPTION
See https://github.com/asdf-format/asdf-standard/pull/478 for more details

Update test requirements to use new pytest-asdf-plugin

On main 354 tests passed:
https://github.com/asdf-format/asdf-wcs-schemas/actions/runs/17036619339/job/48290499438#step:5:98

With this PR 354 tests passed:
https://github.com/asdf-format/asdf-wcs-schemas/actions/runs/17047970459/job/48328491990?pr=77#step:5:98